### PR TITLE
Enhancement 03 - Find locations

### DIFF
--- a/index.js
+++ b/index.js
@@ -23,6 +23,10 @@ db.once('open', () => {
       flush();
       break;
     }
+    case 'find': {
+      findLocation();
+      break;
+    }
     default: {
       saveLocation();
     }
@@ -84,6 +88,68 @@ function saveMultiple(count) {
   Location.insertMany(locations)
     .then(locations => {
       console.log(locations);
+      process.exit(0);
+    })
+    .catch(err => {
+      console.error(err);
+      process.exit(1);
+    });
+}
+
+function findLocation() {
+
+  var latitudeRange, longitudeRange, timestampRange;
+
+  var query = Location.find({});
+
+  // Latitude Range
+  if(process.env.LATITUDE_RANGE){
+    latitudeRange = process.env.LATITUDE_RANGE.split('-');
+    if(latitudeRange.length == 1){
+      query.where('latitude').equals(latitudeRange[0]);
+    }else{
+      if(latitudeRange[0]){
+        query.where('latitude').gte(latitudeRange[0]);
+      }
+      if(latitudeRange[1]){
+        query.where('latitude').lte(latitudeRange[1]);
+      }
+    }
+  }
+
+  // Longitude Range
+  if(process.env.LONGITUDE_RANGE){
+    longitudeRange = process.env.LONGITUDE_RANGE.split('-');
+    if(longitudeRange.length == 1){
+      query.where('longitude').equals(longitudeRange[0]);
+    }else{
+      if(longitudeRange[0]){
+        query.where('longitude').gte(longitudeRange[0]);
+      }
+      if(longitudeRange[1]){
+        query.where('longitude').lte(longitudeRange[1]);
+      }
+    }
+  }
+
+  // Timestamp range
+  if(process.env.TIMESTAMP_RANGE){
+    timestampRange = process.env.TIMESTAMP_RANGE.split('-');
+    if(timestampRange.length == 1){
+      query.where('timestamp').equals(timestampRange[0]);
+    }else{
+      if(timestampRange[0]){
+        query.where('timestamp').gte(timestampRange[0]);
+      }
+      if(timestampRange[1]){
+        query.where('timestamp').lte(timestampRange[1]);
+      }
+    }
+  }
+
+  query.then(locations => {
+      console.log(locations);
+      console.log('Results :' + locations.length);
       process.exit(0);
     })
     .catch(err => {


### PR DESCRIPTION
Added capability to search for a location by latitude, longitude and timestamp.
The pair of values for the range search has to be separated by '-' character.

Synthax:
`ACTION=find LATITUDE_RANGE=<lower bound>-<upper bound> LONGITUDE_RANGE=<lower bound>-<upper bound> TIMESTAMP_RANGE=<lower bound>-<upper bound> npm start`

Example:
`$ACTION=find LATITUDE_RANGE=20-30 npm start`

If it is needed to search for the exact value rather than a range just specify only the value in front of the relevant tag.

Synthax:
`ACTION=find LATITUDE_RANGE=<value> LONGITUDE_RANGE=<value> TIMESTAMP_RANGE=<value> npm start
`
Example:
`ACTION=find LONGITUDE_RANGE=75 npm start`

**Known Issues:**
Suppose that the db contains 10 location records as follows.
 
```
{ "_id" : ObjectId("58ada24688ce633e2c267830"), "__v" : 0, "longitude" : "72.93", "latitude" : "11.46", "timestamp" : "1487774278134" }
{ "_id" : ObjectId("58ada24688ce633e2c267831"), "__v" : 0, "longitude" : "94", "latitude" : "87.37", "timestamp" : "1487774278138" }
{ "_id" : ObjectId("58ada24688ce633e2c267832"), "__v" : 0, "longitude" : "1.3", "latitude" : "11.7", "timestamp" : "1487774278138" }
{ "_id" : ObjectId("58ada24688ce633e2c267833"), "__v" : 0, "longitude" : "179.58", "latitude" : "20.07", "timestamp" : "1487774278138" }
{ "_id" : ObjectId("58ada24688ce633e2c267834"), "__v" : 0, "longitude" : "171.29", "latitude" : "74.68", "timestamp" : "1487774278138" }
{ "_id" : ObjectId("58ada24688ce633e2c267835"), "__v" : 0, "longitude" : "45.81", "latitude" : "89.04", "timestamp" : "1487774278138" }
{ "_id" : ObjectId("58ada24688ce633e2c267836"), "__v" : 0, "longitude" : "114.13", "latitude" : "67.34", "timestamp" : "1487774278138" }
{ "_id" : ObjectId("58ada24688ce633e2c267837"), "__v" : 0, "longitude" : "56.48", "latitude" : "76.84", "timestamp" : "1487774278138" }
{ "_id" : ObjectId("58ada24688ce633e2c267838"), "__v" : 0, "longitude" : "59.82", "latitude" : "80.88", "timestamp" : "1487774278138" }
{ "_id" : ObjectId("58ada24688ce633e2c267839"), "__v" : 0, "longitude" : "13.03", "latitude" : "67.92", "timestamp" : "1487774278138" }
```

When you execute 
`db.locations.find({ latitude: { '$lte': "99" } }) `
it returns all the records which have latitude value less than 99. 

and for
`db.locations.find({ latitude: { '$lte': "100" } }) `
it returns nothing. 
